### PR TITLE
Update xhr polyfill to set onload

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -24,6 +24,10 @@ var XHR = global.XMLHttpRequest = function() {
 		return oldOpen.apply(this, args);
 	};
 
+	// In browsers these default to null
+	this.onload = null;
+	this.onerror = null;
+
 	// jQuery checks for this property to see if XHR supports CORS
 	this.withCredentials = true;
 };


### PR DESCRIPTION
In browsers xhr.onload is initially set to null. This is used by some
libraries to detect if onload is supported.