### PR TITLE
Move the XHR open to the prototype

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -7,22 +7,8 @@ var XHR = global.XMLHttpRequest = function() {
 	this._hackSend = this.send;
 	this.send = XHR.prototype.send;
 
-	var oldOpen = this.open;
-	this.open = function() {
-		var req = global.doneSsr.request;
-		var baseUri = req.url || "";
-		if (req.protocol && req.get) {
-			baseUri = req.protocol + '://' + req.get("host") + baseUri;
-		}
-		var args = Array.prototype.slice.call(arguments);
-		var reqURL = args[1];
-
-		if ( reqURL && !fullUrl.test( reqURL ) ) {
-			args[1] = url.resolve( baseUri, reqURL );
-		}
-
-		return oldOpen.apply(this, args);
-	};
+	this._hackOpen = this.open;
+	this.open = XHR.prototype.open;
 
 	// In browsers these default to null
 	this.onload = null;
@@ -31,6 +17,23 @@ var XHR = global.XMLHttpRequest = function() {
 	// jQuery checks for this property to see if XHR supports CORS
 	this.withCredentials = true;
 };
+
+XHR.prototype.open = function() {
+	var req = global.doneSsr.request;
+	var baseUri = req.url || "";
+	if (req.protocol && req.get) {
+		baseUri = req.protocol + '://' + req.get("host") + baseUri;
+	}
+	var args = Array.prototype.slice.call(arguments);
+	var reqURL = args[1];
+
+	if ( reqURL && !fullUrl.test( reqURL ) ) {
+		args[1] = url.resolve( baseUri, reqURL );
+	}
+
+	return this._hackOpen.apply(this, args);
+};
+
 
 XHR.prototype.send = function () {
 	return this._hackSend.apply(this, arguments);


### PR DESCRIPTION
the `open` function should be on the XHR prototype so that it can be
wrapped in Zone hooks. Using same logic as we do for send.