### PR TITLE
Default to using package.json

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var ssr = require("done-ssr");
 require("./xhr");
 
 module.exports = function(system, options) {
+	system = system || {};
 	var pkgPath = path.join(path.dirname(system.config), 'package.json');
 	var pkg = require(pkgPath);
 


### PR DESCRIPTION
This allows the user to do:

```js
var ssr = require("done-ssr-middleware");

app.use(ssr());
```

Without providing a `system` object.