### PR TITLE
Allow passing 'main' config in production

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,27 +3,28 @@ var os = require('os');
 
 var ssr = require("done-ssr");
 
-module.exports = function(system, options) {
-	system = system || {};
-	var pkgPath = path.join(path.dirname(system.config), 'package.json');
+module.exports = function(stealConfig, options) {
+	var steal = stealConfig || {};
+	var pkgPath = path.join(path.dirname(steal.config), 'package.json');
 	var pkg = require(pkgPath);
 
 	// Default to using the npm plugin
-	if(!system.config) {
-		system.config = pkgPath + '!npm';
+	if(!steal.config) {
+		steal.config = pkgPath + '!npm';
 	}
 	// liveReload is off by default.
-	system.liveReload = !!system.liveReload;
-	system.liveReloadAttempts = system.liveReloadAttempts || 3;
-	system.liveReloadHost = os.hostname();
+	steal.liveReload = !!steal.liveReload;
+	steal.liveReloadAttempts = steal.liveReloadAttempts || 3;
+	steal.liveReloadHost = os.hostname();
 
 	// In production we need to pass in the main, otherwise it doesn't know what
 	// bundle to load from.
-	if(process.env.NODE_ENV === 'production') {
-		system.main = (pkg.system && pkg.system.main) || (pkg.steal && pkg.steal.main) || pkg.main;
+	if(process.env.NODE_ENV === 'production' && !steal.main) {
+		steal.main = (pkg.system && pkg.system.main) ||
+			(pkg.steal && pkg.steal.main) || pkg.main;
 	}
 
-	var render = ssr(system, options);
+	var render = ssr(steal, options);
 
 	return function (req, res, next) {
 		var stream = render(req);

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "basics-can",
   "version": "0.0.1",
-  "main": "does-not-exist.stache!done-autorender",
+  "main": "progressive/index.stache!done-autorender",
   "dependencies": {
     "can-component": "^3.0.4",
     "can-fixture": "^1.0.11",
@@ -14,7 +14,6 @@
     "done-css": "^3.0.0-alpha.2"
   },
   "steal": {
-    "main": "progressive/index.stache!done-autorender",
     "envs": {
       "someenv": {
         "renderingBaseURL": "http://example.com/",


### PR DESCRIPTION
This fixes a problem where in production mode the 'main' config would be
overridden by some defaults. This forces the middleware to prefer the
user-provided main. Fixes #25